### PR TITLE
Fix for `.getElapsed()` crash when VO is stopped.

### DIFF
--- a/src/media/VOPlayer.js
+++ b/src/media/VOPlayer.js
@@ -154,6 +154,12 @@
 	p.getElapsed = function()
 	{
 		var total = 0, item, i;
+        
+        if(!this.playing)
+        {
+            return 0;
+        }
+        
 		for(i = 0; i < this._listCounter; ++i)
 		{
 			item = this.soundList[i];

--- a/src/media/VOPlayer.js
+++ b/src/media/VOPlayer.js
@@ -155,7 +155,7 @@
 	{
 		var total = 0, item, i;
         
-        if(!this.playing)
+        if(!this.soundList)
         {
             return 0;
         }


### PR DESCRIPTION
`this.soundList` is null, causing a crash to occur if `.getElapsed()` is called after VO is stopped. Not sure what makes the most sense for this case, but I have it returning `0` when `!this.soundList`.