### PR TITLE
Fix for _listeners in the EventDispatcher…

### DIFF
--- a/src/events/EventDispatcher.js
+++ b/src/events/EventDispatcher.js
@@ -16,10 +16,10 @@
 	{
 		/**
 		 * The collection of listeners
-		 * @property {Array} _listeners
+		 * @property {Object} _listeners
 		 * @private
 		 */
-		this._listeners = [];
+		this._listeners = {};
 
 		/**
 		 * If the dispatcher is destroyed
@@ -55,7 +55,7 @@
 	{
 		if (this._destroyed) return;
 
-		if (this._listeners[type] !== undefined)
+		if (this._listeners.hasOwnProperty(type) && (this._listeners[type] !== undefined))
 		{
 			// copy the listeners array
 			var listeners = this._listeners[type].slice();
@@ -179,7 +179,7 @@
 		// remove all
 		if (name === undefined)
 		{
-			this._listeners = [];
+			this._listeners = {};
 		}
 		// remove multiple callbacks
 		else if (Array.isArray(callback))

--- a/src/events/EventDispatcher.js
+++ b/src/events/EventDispatcher.js
@@ -130,9 +130,12 @@
 			for (var i = 0, nl = names.length; i < nl; i++)
 			{
 				n = names[i];
-				listener = this._listeners[n];
-				if (!listener)
+				if (this._listeners.hasOwnProperty(n))
+                {
+    				listener = this._listeners[n];
+                } else {
 					listener = this._listeners[n] = [];
+                }
 
 				if (once)
 				{
@@ -198,10 +201,11 @@
 			for (var i = 0, nl = names.length; i < nl; i++)
 			{
 				n = names[i];
-				listener = this._listeners[n];
-				if (listener)
+				if (this._listeners.hasOwnProperty(n))
 				{
-					// remove all listeners for that event
+    				listener = this._listeners[n];
+	
+    				// remove all listeners for that event
 					if (callback === undefined)
 					{
 						listener.length = 0;
@@ -233,7 +237,7 @@
 	{
 		if (!name) return false;
 
-		var listeners = this._listeners[name];
+		var listeners = this._listeners.hasOwnProperty(name);
 		if (!listeners) return false;
 		if (!callback)
 			return listeners.length > 0;

--- a/src/events/EventDispatcher.js
+++ b/src/events/EventDispatcher.js
@@ -235,9 +235,9 @@
 	 */
 	p.has = function(name, callback)
 	{
-		if (!name) return false;
+		if (!name || !this._listeners.hasOwnProperty(name)) return false;
 
-		var listeners = this._listeners.hasOwnProperty(name);
+		var listeners = this._listeners[name];
 		if (!listeners) return false;
 		if (!callback)
 			return listeners.length > 0;


### PR DESCRIPTION
This changes `_listeners` to an Object (rather than an Array) and prevents prototype properties from being included as if they're listener arrays. For example, in the previous iteration, `.trigger('shift')` or `.on('shift', function(){})` calls result in errors due to `_listeners['shift']` returning an already-existing prototype method and not an Array.