### PR TITLE
Made the constructor method added by "extend" a non-enumerable property.

### DIFF
--- a/src/utils/extend.js
+++ b/src/utils/extend.js
@@ -35,18 +35,18 @@
 			}
 			var p = parent.prototype;
 			child.prototype = Object.create(p);
-            Object.defineProperty(child.prototype, '__parent', {
-                configurable: true,
-                writable: true,
-                value: p
-            });
+			Object.defineProperty(child.prototype, '__parent', {
+				configurable: true,
+				writable: true,
+				value: p
+			});
 		}
 		// Add the constructor
-        Object.defineProperty(child.prototype, 'constructor', {
-            configurable: true,
-            writable: true,
-            value: child
-        });
+		Object.defineProperty(child.prototype, 'constructor', {
+			configurable: true,
+			writable: true,
+			value: child
+		});
 
 		// Add extend to each class to easily extend
 		// by calling MyClass.extend(SubClass)

--- a/src/utils/extend.js
+++ b/src/utils/extend.js
@@ -35,12 +35,15 @@
 			}
 			var p = parent.prototype;
 			child.prototype = Object.create(p);
-			child.prototype.__parent = p;
+            Object.defineProperty(child.prototype, '__parent', {
+                configurable: true,
+                writable: true,
+                value: p
+            });
 		}
 		// Add the constructor
         Object.defineProperty(child.prototype, 'constructor', {
             configurable: true,
-            enumerable: false,
             writable: true,
             value: child
         });

--- a/src/utils/extend.js
+++ b/src/utils/extend.js
@@ -38,7 +38,12 @@
 			child.prototype.__parent = p;
 		}
 		// Add the constructor
-		child.prototype.constructor = child;
+        Object.defineProperty(child.prototype, 'constructor', {
+            configurable: true,
+            enumerable: false,
+            writable: true,
+            value: child
+        });
 
 		// Add extend to each class to easily extend
 		// by calling MyClass.extend(SubClass)


### PR DESCRIPTION
I wanted to propose this change, since there doesn't seem to be a good reason to allow the constructor to be enumerable for extended classes. I was unsure about configurable and writable, so they remain as is.