### PR TITLE
Passing the game's asset preloading progress to container.

### DIFF
--- a/src/container-client/ContainerClientPlugin.js
+++ b/src/container-client/ContainerClientPlugin.js
@@ -48,6 +48,12 @@
 				container.send('keepFocus', data);
 			});
 
+		// Pass along preloading progress
+		this.on('progress', function(e)
+		{
+			this.container.send('progress', e);
+		});
+
 		// When the preloading is done
 		this.once('beforeInit', function()
 		{


### PR DESCRIPTION
I want to propose relaying "progress" events from the game to the container. I think it makes sense to add this functionality so that the hosting page / container knows the progress of the game load. For example, this allows the container to display a loading animation, progress bar, or related behavior while the game performs its initial load.

This can be handled already by creating the "progress" relay in a given game and then handling it in the container's JavaScript, but by providing the connection in SpringRoll and SpringRollContainer, the connected behavior needn't be hand-coded for each game on a given site.

Related SpringRollContainer pull request: https://github.com/SpringRoll/SpringRollContainer/pull/4