### PR TITLE
Fix Sound.fadeOut on loading sounds.

### DIFF
--- a/src/media/Sound.js
+++ b/src/media/Sound.js
@@ -657,6 +657,11 @@
 				//fade the last played instance
 				inst = sound.playing[sound.playing.length - 1];
 			}
+			else if (s.loadState == LoadStates.loading)
+			{
+				this.stop(aliasOrInst);
+				return;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Fixes the behavior of Sound.fadeOut() on sounds that are currently loading, by stopping the audio entirely instead of allowing the audio to play when it finishes loading.

Should fix #122 