### PR TITLE
Removed default forcing IE11 to use PIXI.CanvasRenderer.

### DIFF
--- a/src/displays/pixi/PixiDisplay.js
+++ b/src/displays/pixi/PixiDisplay.js
@@ -93,14 +93,6 @@
 		if (rendererOptions.transparent && !preMultAlpha)
 			rendererOptions.transparent = "notMultiplied";
 
-		//check for IE11 because it tends to have WebGL problems (especially older versions)
-		//if we find it, then make Pixi use to the canvas renderer instead
-		if (options.forceContext != "webgl")
-		{
-			var ua = window.navigator.userAgent;
-			if (ua.indexOf("Trident/7.0") > 0)
-				options.forceContext = "canvas2d";
-		}
 		if (options.forceContext == "canvas2d")
 		{
 			this.renderer = new CanvasRenderer(this.width, this.height, rendererOptions);


### PR DESCRIPTION
When SpringRoll offically moves to PIXI v4, I recommend removing this in favor of allowing PIXI's auto-detect to handle this behavior instead.

[According to this thread](https://github.com/pixijs/pixi.js/issues/3336#issuecomment-272972380), IE11 is doing better at supporting webGL, and from a developer perspective I think it would be better to let the default renderer coincide with PIXI's `autoDetectRender`. If desired, the current behavior could be replicated by the game developer explicitly setting

    displayOptions: {
        forceContext: (window.navigator.userAgent.indexOf("Trident/7.0") > 0) ? "canvas2d" : "")
    }
