### PR TITLE
Feature/more docs

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -39,7 +39,7 @@ The SpringRoll Application class has a general [StateManager](./state) instance 
 properties that can be changed via the container or outside environment. Property changes can be subscribed to allow the
 game to react appropriately to the given situation.
 When certain features are enabled, SpringRoll warns if an associated state change listener is missing. For instance,
-if `sound` is enabled as a feature of the game, there must be a subscriber to the `soundMuted` state:
+if `sound` is enabled as a feature of the game, there must be a subscriber to the `soundVolume` state:
 
 ```javascript
 var myApp = new springroll.Application({

--- a/src/README.md
+++ b/src/README.md
@@ -119,3 +119,5 @@ myApp.state.ready.subscribe(function() {
   myApp.state.scene.value = new TitleScene();
 });
 ```
+
+For more information on adding your own properties, see the [StateManager documentation](./state)

--- a/src/README.md
+++ b/src/README.md
@@ -35,6 +35,9 @@ Note that if any of `vo`, `music`, or `sfx` are available features, `sound` will
 Also, all of these features are marked `false` by default.
 
 ## Handling State Change
+The SpringRoll Application class has a general [StateManager](./state) instance attached for managing important
+properties that can be changed via the container or outside environment. Property changes can be subscribed to allow the
+game to react appropriately to the given situation.
 When certain features are enabled, SpringRoll warns if an associated state change listener is missing. For instance,
 if `sound` is enabled as a feature of the game, there must be a subscriber to the `soundMuted` state:
 

--- a/src/README.md
+++ b/src/README.md
@@ -36,10 +36,10 @@ Also, all of these features are marked `false` by default.
 
 ## Handling State Change
 The SpringRoll Application class has a general [StateManager](./state) instance attached for managing important
-properties that can be changed via the container or outside environment. Property changes can be subscribed to allow the
-game to react appropriately to the given situation.
+properties that can be changed via the container or outside environment.
+Developers can subscribe to property changes, allowing the game to react appropriately to the given situation.
 When certain features are enabled, SpringRoll warns if an associated state change listener is missing. For instance,
-if `sound` is enabled as a feature of the game, there must be a subscriber to the `soundVolume` state:
+if the developer enables `sound` as a feature of the game, a subscriber to the `soundVolume` state must exist:
 
 ```javascript
 var myApp = new springroll.Application({
@@ -100,8 +100,8 @@ myApp.state.playOptions.subscribe(playOptions => {
 ```
 
 ## Custom State Management
-The Application's `StateManager` instance can also be used for custom purposes. For instance, scene management can
-be managed in a declarative way:
+The Application's `StateManager` instance can also be used for custom purposes.
+For instance, developers can declaratively control scene management:
 
 ```javascript
 var myApp = new Application();

--- a/src/README.md
+++ b/src/README.md
@@ -98,3 +98,24 @@ myApp.state.playOptions.subscribe(playOptions => {
   console.log('New playOptions value set to', playOptions);
 });
 ```
+
+## Custom State Management
+The Application's `StateManager` instance can also be used for custom purposes. For instance, scene management can
+be managed in a declarative way:
+
+```javascript
+var myApp = new Application();
+
+myApp.state.addField('scene', null);
+myApp.state.scene.subscribe(function(newScene, oldScene) {
+  renderer.stage.removeChild(oldScene);
+  oldScene.teardown();
+
+  renderer.stage.addChild(newScene);
+  newScene.setup();
+});
+
+myApp.state.ready.subscribe(function() {
+  myApp.state.scene.value = new TitleScene();
+});
+```

--- a/src/debug/Debugger.js
+++ b/src/debug/Debugger.js
@@ -195,6 +195,7 @@ export class Debugger {
 
   /**
    * Disables or enables all debugger instances.
+   * TODO: Remove the parameter here, and add a disable method as well
    * @static
    * @param {boolean} flag
    * @returns {void}

--- a/src/debug/README.md
+++ b/src/debug/README.md
@@ -1,3 +1,34 @@
 # Debugger
 
-Simplifies logging events to the console for debugging purposes.
+The Debugger module provides a centralized logging solution for SpringRoll games.
+
+```javascript
+Debugger.log('general', 'A general log');
+Debugger.log('log', 'Normal log');
+Debugger.log('warn', 'A warning');
+Debugger.log('debug', 'A debug message');
+Debugger.log('error', 'An error has occurred');
+```
+
+The debugger can be toggled off with the enable flag:
+
+```javascript
+Debugger.enable(false);
+```
+
+For more fine-grained control, you can set the minimum logging level:
+
+```javascript
+Debugger.minLevel('WARN');
+```
+
+Now, only `WARN` and `ERROR` level messages will be reported, and `GENERAL`, `DEBUG`, and `INFO` will not.
+In particular, the message levels are as follows:
+* `GENERAL` : 1
+* `DEBUG` : 2
+* `INFO` : 3
+* `WARN` : 4
+* `ERROR` : 5
+
+Because of this, if the min debug level is set to `INFO`, `DEBUG` and `GENERAL` are disabled, but not `WARN` and `ERROR`
+Also, this mapping can be accessed programmatically from `Debugger.LEVEL` if needed.

--- a/src/debug/README.md
+++ b/src/debug/README.md
@@ -22,7 +22,7 @@ For more fine-grained control, you can set the minimum logging level:
 Debugger.minLevel('WARN');
 ```
 
-Now, only `WARN` and `ERROR` level messages will be reported, and `GENERAL`, `DEBUG`, and `INFO` will not.
+Now, only `WARN` and `ERROR` level messages will print, and `GENERAL`, `DEBUG`, and `INFO` will not.
 In particular, the message levels are as follows:
 * `GENERAL` : 1
 * `DEBUG` : 2
@@ -30,5 +30,7 @@ In particular, the message levels are as follows:
 * `WARN` : 4
 * `ERROR` : 5
 
-Because of this, if the min debug level is set to `INFO`, `DEBUG` and `GENERAL` are disabled, but not `WARN` and `ERROR`
-Also, this mapping can be accessed programmatically from `Debugger.LEVEL` if needed.
+Due to the message level ordering, if the minimum debug level is set to `INFO`, then `DEBUG` and `GENERAL` are disabled
+and will not print, but `WARN` and `ERROR` will still print.
+
+This mapping is programmatically accessible from `Debugger.LEVEL`.

--- a/src/scale-manager/README.md
+++ b/src/scale-manager/README.md
@@ -1,3 +1,22 @@
 # Scale Manager
 
-Simplifies listening to resize events by passing the relevant data to a provided callback.
+A utility class for listen for resize events.
+
+```javascript
+var scaleManager = new ScaleManager(function(resizeData) {
+  console.log('This is called on window resize');
+
+  console.log('Window width is', resizeData.width);
+  console.log('Window height is', resizeData.height);
+  console.log('Window aspect ratio is', resizeData.ratio);
+});
+```
+
+If you do not have a listener ready at the time of construction or you need to replace the existing listener, the
+`enable` method exists for that purpose:
+
+```javascript
+scaleManager.enable(function(resizeData) {
+  console.log('The old listener is replaced with this one!', resizeData);
+});
+```

--- a/src/scale-manager/README.md
+++ b/src/scale-manager/README.md
@@ -1,6 +1,5 @@
 # Scale Manager
-
-A utility class for listen for resize events.
+A utility class that listens for resize events.
 
 ```javascript
 var scaleManager = new ScaleManager(function(resizeData) {
@@ -12,8 +11,8 @@ var scaleManager = new ScaleManager(function(resizeData) {
 });
 ```
 
-If you do not have a listener ready at the time of construction or you need to replace the existing listener, the
-`enable` method exists for that purpose:
+The `enable` method exists in case you do not have a listener ready at the time of construction or need to replace the
+existing listener.
 
 ```javascript
 scaleManager.enable(function(resizeData) {

--- a/src/state/README.md
+++ b/src/state/README.md
@@ -1,14 +1,36 @@
 # State Manager
+The `StateManager` is a class that manages a group of subscribable [`Property`](./Property.js) instances.
+The provides functionality for registration of new properties, and for subscribing to existing properties.
 
-A class for managing a group of subscribable properties together. Allows for the registration of new properties.
+An example usage:
 
-For example:
-```
+```javascript
 var manager = new StateManager();
+
+// adds a new field called 'paused' to the manager, and sets it initially to false
 manager.addField('paused', false);
-manager.paused.subscribe(function(newValue) {
-  console.log('New value is ', newValue);
+
+// listen for any changes on the newly created 'paused' field.
+manager.paused.subscribe(function(newValue, oldValue) {
+  console.log('Value changed from', oldValue, 'to', newValue);
 })
 
-manager.paused = true;
+// change the field's value, which will trigger the handler above
+manager.paused.value = true;
+```
+
+## Standalone Property instances
+A `Property` instance can also be instantiated individually without using a `StateManager`:
+
+```javascript
+// creates the property, defaulting the value to false
+const isPaused = new Property(false);
+
+// subscribe for changes to the property
+isPaused.subscribe(function(newValue, oldValue) {
+  console.log('Value changed from', oldValue, 'to', newValue);
+});
+
+// the property can be changed similar to the previous case, and the handler will be triggered appropriately
+isPaused.value = true;
 ```

--- a/src/state/README.md
+++ b/src/state/README.md
@@ -1,13 +1,13 @@
 # State Manager
 The `StateManager` is a class that manages a group of subscribable [`Property`](./Property.js) instances.
-The provides functionality for registration of new properties, and for subscribing to existing properties.
+This class provides functionality for registration of new properties and subscription to existing properties.
 
 An example usage:
 
 ```javascript
 var manager = new StateManager();
 
-// adds a new field called 'paused' to the manager, and sets it initially to false
+// adds a new field called 'paused' to the manager with an initial value of false
 manager.addField('paused', false);
 
 // listen for any changes on the newly created 'paused' field.
@@ -31,6 +31,6 @@ isPaused.subscribe(function(newValue, oldValue) {
   console.log('Value changed from', oldValue, 'to', newValue);
 });
 
-// the property can be changed similar to the previous case, and the handler will be triggered appropriately
+// the property can change similarly to the previous case, the handler triggering appropriately
 isPaused.value = true;
 ```


### PR DESCRIPTION
Just beefing up some documentation.

Tasks:
- [x] Documentation
- [ ] Unit Tests
- [ ] Typescript Typings
- [ ] Haxe Externs
- [ ] `npm run build:full`

No code changed, so I didn't check anything else.