### PR TITLE
Hotfix/caption rendering typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "springroll",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "dist/SpringRoll.js",
   "module": "dist/SpringRoll.js",

--- a/typings/Renderer.d.ts
+++ b/typings/Renderer.d.ts
@@ -6,7 +6,7 @@ export interface IRender {
 }
 
 export class DOMRenderer {
-  constructor(element : HTMLElement, templateVariables : object);
+  constructor(element : HTMLElement, templateVariables?: object);
   start(templateVariables: object);
   stop();
 }

--- a/typings/Renderer.d.ts
+++ b/typings/Renderer.d.ts
@@ -6,6 +6,7 @@ export interface IRender {
 }
 
 export class DOMRenderer {
+  constructor(element : HTMLElement, templateVariables : object);
   start(templateVariables: object);
   stop();
 }


### PR DESCRIPTION
Tasks:
- [ ] Documentation
- [ ] Unit Tests
- [x] Typescript Typings
- [ ] Haxe Externs
- [ ] `npm run build:full`

Fixing a bug where `DOMRenderer` wasn't properly declaring it's constructor signature which was causing TypeScript compilation to fail when using the `HTMLRenderer` setup declared in the docs.