### PR TITLE
The typescript compiler doesn't like Number for some reason

### DIFF
--- a/typings/SafeScaleManager.d.ts
+++ b/typings/SafeScaleManager.d.ts
@@ -1,13 +1,13 @@
 import { ScaledEntity } from "../src/scale-manager/ScaledEntity";
 
 export interface Point {
-  x: Number;
-  y: Number;
+  x: number;
+  y: number;
 }
 
 export interface ScaleEvent {
-  width: Number;
-  height: Number;
+  width: number;
+  height: number;
   scale: Point;
 }
 
@@ -24,10 +24,10 @@ export interface ScaledEntity {
 }
 
 export interface SafeScaleManagerConfig {
-  width: Number;
-  height: Number;
-  safeWidth?: Number;
-  safeHeight?: Number;
+  width: number;
+  height: number;
+  safeWidth?: number;
+  safeHeight?: number;
   callback: ScaleCallback; 
 }
 


### PR DESCRIPTION
TypeScript seems to prefer `number` over `Number` it seems... Using the setup from the README:

```typescript
// setup the scale manager
const scaleManager = new SafeScaleManager({
    width: 1320,
    height: 780,
    safeWidth: 1024,
    safeHeight: 660,
    callback: ({ width, height, scale }) => {
        // -- PIXI -- //
        const view = app.view;
        const stage = app.stage;
        const renderer = app.renderer;
        stage.position.set(renderer.width / 2, renderer.height / 2);
        stage.scale.set(scale.x, scale.y);
        stage.pivot.x = renderer.width / 2;
        stage.pivot.y = renderer.height / 2;
        view.style.width = width + 'px';
        view.style.height = height + 'px';
        view.style.position = 'absolute'
        view.style.left = '0px';
        view.style.top = '0px';
    }
});
```

I get a compile error:

```
      TS2345: Argument of type 'Number' is not assignable to parameter of type 'number'.
  'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
```

This may be a symptom of my particular TypeScript configuration, but it's probably best to fix this. `number` does make more sense here