### PR TITLE
added npm deploy action

### DIFF
--- a/.github/workflows/npm-deploy.yml
+++ b/.github/workflows/npm-deploy.yml
@@ -1,0 +1,38 @@
+name: npm-deploy
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+          registry-url: https://registry.npmjs.org/
+
+      - name: install
+        run: |
+          npm ci
+        env:
+          CI: true
+
+      - name: build
+        run: |
+          npm run build:full
+        env:
+          CI: true
+
+      - name: test
+        run: npm run github-test
+        env:
+          CI: true
+
+      - name: publish
+        run: npm publish
+        env:
+          CI: true
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
We'll need to add an NPM repository token to the github secrets called `npm_token`

This is a task to automagically deploy to npm when you tag a release on github

Tasks:
- [ ] Documentation
- [ ] Unit Tests
- [ ] Typescript Typings
- [ ] `npm run build:full`