### PR TITLE
Typings updates

### DIFF
--- a/typings/Controller.d.ts
+++ b/typings/Controller.d.ts
@@ -1,22 +1,22 @@
 export type KeyState = 0 | 1 | 2;
 export type KeyTemplate = {
-  down: Function;
+  down?: () => void;
   key: string;
-  up: Function;
+  up?: () => void;
 }
 
 export class Key {
-  constructor(key: string, down: Function, up: Function);
+  constructor(key: string, down?: () => void, up?: () => void);
   key: string;
   actions: {
-    up: Function,
-    down: Function
+    up?: () => void,
+    down?: () => void
   }
   updateState(state?: KeyState): void;
   action(): void;
-  readonly state: KeyState
+  readonly state: KeyState;
 
-  private _state: KeyState
+  private _state: KeyState;
 }
 
 export class Controller {

--- a/typings/SafeScaleManager.d.ts
+++ b/typings/SafeScaleManager.d.ts
@@ -1,5 +1,3 @@
-import { ScaledEntity } from "../src/scale-manager/ScaledEntity";
-
 export type ViewAreaRect = {
   x: number;
   y: number;


### PR DESCRIPTION
* Remove src import from SafeScaleManager typings - it causes the `ScaledEntity` interface defined in the file to be merged with (effectively overridden by) `any`.
* Mark key callbacks as optional and strongly type them in Controller types.