### PR TITLE
Typings Function fixes

### DIFF
--- a/src/hints/IdleTimer.js
+++ b/src/hints/IdleTimer.js
@@ -59,7 +59,7 @@ export class IdleTimer {
    */
   dispatch() {
     for (let i = 0; i < this.listeners.length; i++) {
-      this.listeners[i](this['_value']);
+      this.listeners[i]();
     }
     this.reset();
   }

--- a/typings/Application.d.ts
+++ b/typings/Application.d.ts
@@ -101,16 +101,16 @@ export class ApplicationPlugin {
 }
 
 
-
+export type PropertyChangeListener<T> = (value: T, previousValue: T) => void;
 
 export class Property<T> {
   constructor(initialValue: T, alwaysNotify?: boolean);
   private _value: T;
-  private listeners: Function[];
+  private listeners: PropertyChangeListener<T>[];
   value: T;
   notifyChange(): void;
-  subscribe(callback:(value: T, previousValue: T) => void): void;
-  unsubscribe(callback: Function): void;
+  subscribe(callback: PropertyChangeListener<T>): void;
+  unsubscribe(callback: PropertyChangeListener<T>): void;
   hasListeners(): boolean;
 }
 

--- a/typings/Hint.d.ts
+++ b/typings/Hint.d.ts
@@ -1,22 +1,22 @@
 export interface IHintPlayer {
-  play:Function;
+  play:() => void;
 }
 
 export type HintCallback = () => any;
 
 export class HintSequencePlayer implements IHintPlayer {
-  play:Function;
+  play(): void;
   add(...hints: HintCallback[]):void;
   remove(...hints: HintCallback[]):void;
-  clear:Function;
+  clear(): void;
 }
 
 export class IdleTimer
 {
-  start(time:Number);
-  stop:Function;
-  reset:Function;
-  dispatch:Function;
-  subscribe(callback:Function);
-  unsubscribe(callback:Function);
+  start(time:Number): void;
+  stop(): void;
+  reset(): void;
+  dispatch(): void;
+  subscribe(callback:() => void): void;
+  unsubscribe(callback:() => void): void;
 }

--- a/typings/Hint.d.ts
+++ b/typings/Hint.d.ts
@@ -13,7 +13,7 @@ export class HintSequencePlayer implements IHintPlayer {
 
 export class IdleTimer
 {
-  start(time:Number): void;
+  start(time?:Number): void;
   stop(): void;
   reset(): void;
   dispatch(): void;

--- a/typings/Renderer.d.ts
+++ b/typings/Renderer.d.ts
@@ -1,25 +1,29 @@
 export interface IRender {
-  start: Function;
-  stop: Function;
-  lineBegin: Function;
-  lineEnd: Function;
+  start: () => void;
+  stop: () => void;
+  lineBegin: (line:{content:string, templateVariables:TemplateVariables}) => void;
+  lineEnd: () => void;
+}
+
+export interface TemplateVariables {
+    [key:string]: any
 }
 
 export class DOMRenderer {
-  constructor(element : HTMLElement, templateVariables?: object);
-  start(templateVariables: object);
-  stop();
+  constructor(element : HTMLElement, templateVariables?: TemplateVariables);
+  start(templateVariables?: TemplateVariables): void;
+  stop(): void;
 }
 
 export class HtmlRenderer extends DOMRenderer implements IRender {
-  lineBegin: Function;
-  lineEnd: Function;
+  lineBegin(line:{content:string, templateVariables:TemplateVariables}): void;
+  lineEnd(): void;
 }
 export class TextRenderer extends DOMRenderer implements IRender {
   sanitize(html: string): string;
-  lineBegin: Function;
-  lineEnd: Function;
+  lineBegin(line:{content:string, templateVariables:TemplateVariables}): void;
+  lineEnd(): void;
 }
 
-export function TemplateRenderer(template: string, args: object): string;
+export function TemplateRenderer(template: string, args: TemplateVariables): string;
 

--- a/typings/ScaleManager.d.ts
+++ b/typings/ScaleManager.d.ts
@@ -1,6 +1,8 @@
+export type ScaleManagerCallback = (event:{width:number, height: number, ratio: number}) => void;
+
 export class ScaleManager {
-    constructor(callback: Function);
+    constructor(callback?: ScaleManagerCallback);
     disable(): void;
-    enable(callback: Function): void;
+    enable(callback: ScaleManagerCallback): void;
     onResize(event: UIEvent): void;
-  }
+}


### PR DESCRIPTION
Replaces all uses of  `Function` with more specific versions in type declarations.
Also, I removed the parameter being passed to IdleTimer callbacks - this _seems_ like a copy/paste error that was just carried through code updates, as IdleTimer has never had a `_value` property, documented or otherwise.