### PR TITLE
Fix type of CaptionPlayer.captions

### DIFF
--- a/typings/Localization.d.ts
+++ b/typings/Localization.d.ts
@@ -37,7 +37,7 @@ export class Caption {
 export class CaptionPlayer {
   constructor(captions: CaptionData, renderer: IRender);
   renderer: IRender;
-  captions: Timedline[];
+  captions: {[name:string]: Caption};
   activeCaption: Caption;
 
   update(deltaTime:number): void;


### PR DESCRIPTION
Corrects the type of `CaptionPlayer.captions` to be the map of `Caption` objects that it is.