### PR TITLE
epic/ SR-12 - Fixing Node package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "springroll",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "",
   "main": "dist/SpringRoll.js",
   "module": "dist/SpringRoll.js",


### PR DESCRIPTION
The version in package.json was accidentally left at 2.6.0, which is preventing the upload to NPM. This PR fixes that.

Ticket: https://pbskids.atlassian.net/browse/SR-12