### PR TITLE
Fixes Closed Captioning glitch where last caption appears for a frame before new caption updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Updated captions RendererDOM to clear out CC text when caption stops.
+
 ## [2.7.0] - 2024-11-04
 
 ### Changed

--- a/src/localization/captions/renderers/RendererDOM.js
+++ b/src/localization/captions/renderers/RendererDOM.js
@@ -39,6 +39,7 @@ export class DOMRenderer extends IRender {
    */
   stop() {
     this.renderTarget.style.visibility = 'hidden';
+    this.renderTarget.innerHTML = '';
     this.templateVariables = {};
   }
 }


### PR DESCRIPTION
`.lineEnd` is not necessarily called before a caption stops playing, so the caption renderer may retain the last caption line. When this occurs, the renderer's DOM element becomes visible before its innerHTML is updated, resulting in a single frame where the old caption text appears before it's updated to the current caption text.

Adding this line removes that errant frame.