### PR TITLE
add repository url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "dist/SpringRoll.js",
   "module": "dist/SpringRoll.js",
   "typings": "typings/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SpringRoll/SpringRoll"
+  },
   "scripts": {
     "build": "npm run build:full",
     "build:map": "rollup -c -m",


### PR DESCRIPTION
The [deploy action](https://github.com/SpringRoll/SpringRoll/actions/runs/21648768339/job/62407586925) was unhappy that the repo url didn't match in the package.json